### PR TITLE
PIL -> Pillow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url='http://github.com/gotlium/django-collage',
     packages=find_packages(exclude=['demo']),
     include_package_data=True,
-    install_requires=['setuptools', 'django', 'sorl-thumbnail', 'PIL'],
+    install_requires=['setuptools', 'django', 'sorl-thumbnail', 'Pillow'],
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
> Could not find a version that satisfies the requirement pil (from versions: )
> No matching distribution found for pil

PIL does not exist in pip registry. We should use Pillow instead of PIL.